### PR TITLE
feature: add support proxies with authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ const attackHandlers = {
 
 > 4. Requests fail to be sent to the target server (Read timeout and variations)
 **Re:** You must put the corresponding proxies in the file `data/proxies.txt`. On each line, put a different proxy that will be used to perform the attack. The format must be the following:
+- `protocol://user:password@host:port` (Proxy with authentication)
 - `protocol://host:port`
 - `host:port` (Uses http as default protocol)
 - `host` (Uses 8080 as default port)

--- a/server/fileLoader.ts
+++ b/server/fileLoader.ts
@@ -28,9 +28,23 @@ export function loadUserAgents() {
 
 export function loadProxies(): Proxy[] {
   const lines = loadFileLines(join(currentPath(), "data/proxies.txt"));
+
+  //RegEx for proxies with authentication (protocol://user:pass@host:port)
+  const authProxiesRegEx = new RegExp(/^(http|https|socks4|socks5|):\/\/(\S+:\S+)@((\w+|\d+\.\d+\.\d+\.\d+):\d+)$/, 'g');
+
   return lines.map((line) => {
-    const [protocol, addr] = line.split("://");
-    const [host, port] = addr.split(":");
-    return { protocol, host, port: parseInt(port) };
+    const [protocol, loginInfo] = line.split("://");
+
+    if (authProxiesRegEx.test(line)) {
+      const [auth, addr] = loginInfo.split("@");
+      const [user, pass] = auth.split(":");
+      const [host, port] = addr.split(":");
+
+      return { protocol, host, port: parseInt(port), username: user, password: pass };
+    } else {
+      const [host, port] = loginInfo.split(":");
+
+      return { protocol, host, port: parseInt(port) };
+    }
   });
 }

--- a/server/lib.ts
+++ b/server/lib.ts
@@ -1,6 +1,8 @@
 export type ProxyProtocol = "http" | "https" | "socks4" | "socks5" | string;
 
 export interface Proxy {
+  username?: string;
+  password?: string;
   protocol: ProxyProtocol;
   host: string;
   port: number;

--- a/server/utils/mcUtils.js
+++ b/server/utils/mcUtils.js
@@ -87,10 +87,10 @@ class MinecraftBufferReader {
 
 export function pingMinecraftServer(host, port, proxy) {
   return new Promise((resolve, reject) => {
-    const { protocol, host: proxyHost, port: proxyPort } = proxy;
+    const { protocol, host: proxyHost, port: proxyPort, username: proxyUsername, password: proxyPassword } = proxy;
 
     const agent = new SocksProxyAgent(
-      `${protocol}://${proxyHost}:${proxyPort}`
+      `${protocol}://${proxyUsername && proxyPassword ? `${proxyUsername}:${proxyPassword}@` : ""}${proxyHost}:${proxyPort}`
     );
 
     const socket = net.createConnection({

--- a/server/workers/httpFloodAttack.js
+++ b/server/workers/httpFloodAttack.js
@@ -27,9 +27,16 @@ const startAttack = () => {
           host: proxy.host,
           port: proxy.port,
         };
+
+        if (proxy.username && proxy.password) {
+          config.proxy.auth = {
+            username: proxy.username,
+            password: proxy.password,
+          }
+        }
       } else if (proxy.protocol === "socks4" || proxy.protocol === "socks5") {
-        config.httpAgent = new SocksProxyAgent(
-          `${proxy.protocol}://${proxy.host}:${proxy.port}`
+        config.httpAgent, config.httpsAgent = new SocksProxyAgent(
+          `${proxy.protocol}://${proxy.username && proxy.password ? `${proxy.username}:${proxy.password}@` : ""}${proxy.host}:${proxy.port}`
         );
       }
 

--- a/server/workers/httpSlowlorisAttack.js
+++ b/server/workers/httpSlowlorisAttack.js
@@ -31,7 +31,7 @@ const startAttack = () => {
         Host: targetHost,
       },
       agent: new SocksProxyAgent(
-        `${proxy.protocol}://${proxy.host}:${proxy.port}`
+        `${proxy.protocol}://${proxy.username && proxy.password ? `${proxy.username}:${proxy.password}@` : ""}${proxy.host}:${proxy.port}`
       ),
     };
 

--- a/server/workers/tcpFloodAttack.js
+++ b/server/workers/tcpFloodAttack.js
@@ -20,7 +20,7 @@ const startAttack = () => {
     socket.setTimeout(2000);
 
     const proxyAgent = new SocksProxyAgent(
-      `${proxy.protocol}://${proxy.host}:${proxy.port}`
+      `${proxy.protocol}://${proxy.username && proxy.password ? `${proxy.username}:${proxy.password}@` : ""}${proxy.host}:${proxy.port}`
     );
 
     setInterval(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function ConfigureProxiesAndAgentsView() {
             onChange={(e) =>
               setConfiguration([e.target.value, configuration[1]])
             }
-            placeholder="socks5://0.0.0.0"
+            placeholder="socks5://0.0.0.0&#10;socks4://user:pass@0.0.0.0:12345"
           ></textarea>
           <p className="pl-1 mt-2 mb-1 italic">uas.txt</p>
           <textarea


### PR DESCRIPTION
Made based on this issue #22

Proxy with auth (example):

> socks4://user:pass@ip:port